### PR TITLE
askUser now has optional default

### DIFF
--- a/src/main/bash/lib/shellUtils.sh
+++ b/src/main/bash/lib/shellUtils.sh
@@ -81,9 +81,19 @@ if [[ " ${LOADED_LIB[*]} " != *" shellUtils.sh "* ]]; then
 	#PARAMETERS
 	# $1 | Prompt | The prompt to place on the screen
 	# $2 | Variable | The name of the variable to store the response
+	# $3 | Default | The default response if none is provided | optional
 	function askUser {
-		log "Asking the user [$1] and storeing it in [$2]" "$INFO" "$TEXT_YELLOW"
-		read -r -p "$1: " "$2"
+		local PROMPT
+		if [ -z "$3" ]; then
+			PROMPT="$1"
+		else
+			PROMPT="$1 [$3]"
+		fi
+		
+		log "Asking the user [$PROMPT] and storing it in [$2]" "$INFO" "$TEXT_YELLOW"
+		local RESPONSE
+		read -r -p "$PROMPT: " "RESPONSE"
+		printf -v "$2" '%s' "${RESPONSE:-$3}"
 	}
 
 	#METHOD


### PR DESCRIPTION
When calling `askUser`, a 3rd and optional param "Default" can be given

If no default is given, the function behaves exactly the same:
```
$> askUser "What's your name" "NAME"
What's your name: Ted
$> echo $NAME
Ted
```
If a default is given, the function will set the default if an empty param is given
```
$> askUser "What's your name" "NAME" "Jake"
What's your name [Jake]:
$> echo $NAME
Jake
```
```
$> askUser "What's your name" "NAME" "Jake"
What's your name [Jake]: Ted
$> echo $NAME
Ted
```